### PR TITLE
Fix reference to KIBA dataset in README.md

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -11,7 +11,7 @@ For each dataset, there are two similarity files, drug-drug and target-target si
 
 These files were used to re-produce the results of two other methods [(Pahikkala et al., 2017)](https://academic.oup.com/bib/article/16/2/325/246479) and [(He et al., 2017)](https://jcheminf.biomedcentral.com/articles/10.1186/s13321-017-0209-z), and also for some experiments in DeepDTA model, please refer to [paper](https://academic.oup.com/bioinformatics/article/34/17/i821/5093245). 
 *  The original Davis data and more explanation can be found [here](http://staff.cs.utu.fi/~aatapa/data/DrugTarget/).
-*  The original KIBA data and more explanation can be found [here](https://jcheminf.biomedcentral.com/articles/10.1186/s13321-017-0209-z).
+*  The original KIBA data and more explanation can be found [here](https://pubs.acs.org/doi/10.1021/ci400709d).
 
 ### Binding affinity files
 


### PR DESCRIPTION
The old link referenced the wrong paper. This one references the original KIBA paper which includes the dataset in the SI.